### PR TITLE
Fix/delete : API 3개 수정

### DIFF
--- a/backend/src/main/java/com/itec0401/backend/domain/clothing/dto/ClothRequestDto.java
+++ b/backend/src/main/java/com/itec0401/backend/domain/clothing/dto/ClothRequestDto.java
@@ -4,18 +4,43 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class ClothRequestDto {
     // Create, Update 둘 다 이 형식
-    private String imageUri;
-    private String name;
-    private String mainCategory;
-    private String subCategory;
-    private String baseColor;
-    private String pointColor;
-    private String textile;
-    private String pattern;
-    private String season;
-    private String style;
-    private String description;
+    private final String imageUri;
+    private final String name;
+    private final String mainCategory;
+    private final String subCategory;
+    private final String baseColor;
+    private final String pointColor;
+    private final String textile;
+    private final String pattern;
+    private final String season;
+    private final String style;
+    private final String description;
+
+    @Builder
+    public ClothRequestDto(
+            String imageUri,
+            String name,
+            String mainCategory,
+            String subCategory,
+            String baseColor,
+            String pointColor,
+            String textile,
+            String pattern,
+            String season,
+            String style,
+            String description) {
+        this.imageUri = imageUri;
+        this.name = name;
+        this.mainCategory = mainCategory;
+        this.subCategory = subCategory;
+        this.baseColor = baseColor;
+        this.pointColor = pointColor;
+        this.textile = textile;
+        this.pattern = pattern;
+        this.season = season;
+        this.style = style;
+        this.description = description;
+    }
 }

--- a/backend/src/main/java/com/itec0401/backend/domain/clothing/dto/DeleteImageUri.java
+++ b/backend/src/main/java/com/itec0401/backend/domain/clothing/dto/DeleteImageUri.java
@@ -1,0 +1,14 @@
+package com.itec0401.backend.domain.clothing.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DeleteImageUri {
+    private final String imageUri;
+
+    @Builder
+    public DeleteImageUri(String imageUri) {
+        this.imageUri = imageUri;
+    }
+}

--- a/backend/src/main/java/com/itec0401/backend/domain/clothing/service/ClothingServiceImpl.java
+++ b/backend/src/main/java/com/itec0401/backend/domain/clothing/service/ClothingServiceImpl.java
@@ -153,9 +153,9 @@ public class ClothingServiceImpl implements ClothingService {
     public List<ClothingData> addClothingInfo(List<Long> clothingIds){
         List<ClothingData> clothingDataDtos = new ArrayList<>();
         for (Long id : clothingIds){
-            Optional<Clothing> clothing = clothingRepository.findById(id);
+            Optional<Clothing> clothing = clothingRepository.findByClothingId(id);
             if (clothing.isEmpty()) {
-                throw new ClothingNotFoundException("Clothing not found");
+                throw new ClothingNotFoundException("addClothingInfo : Clothing not found");
             }
             Clothing c = clothing.get();
             clothingDataDtos.add(ClothingData.toDto(c));

--- a/backend/src/main/java/com/itec0401/backend/domain/coordination/controller/CoordinationController.java
+++ b/backend/src/main/java/com/itec0401/backend/domain/coordination/controller/CoordinationController.java
@@ -33,7 +33,8 @@ public class CoordinationController {
     @Operation(
             summary = "자연어를 이용한 코디 추천 API",
             description = "옷 여러개 선택 + 자연어 한 문장 을 이용해 요청하면, 그 자연어 상황에 맞는 코디를 1개 추천해줌. " +
-                    "추천된 결과는 바로 DB에 저장됨."
+                    "추천된 결과는 바로 DB에 저장됨." +
+                    "생성된 코디 결과를 반환값으로 줌."
     )
     @PostMapping("/rec/natural-language")
     public ResponseEntity<CodiInfoWithImages> coordRecommendUsingNaturalLanguage(@RequestBody NLCodiRequestToSpring dto, Authentication authentication){
@@ -42,7 +43,7 @@ public class CoordinationController {
 
     @Operation(
             summary = "모든 코디 정보 열람 API",
-            description = "코디의 상세 정보가 열람되지는 않음. 추후 수정해야할 수도...(이미지 정보를 같이 반환하는 방향으로..)"
+            description = "코디의 상세 정보가 열람됨."
     )
     @GetMapping
     public ResponseEntity<List<CodiInfoWithImages>> getAllCoordinationInfos(Authentication authentication){

--- a/backend/src/main/java/com/itec0401/backend/domain/coordination/controller/CoordinationController.java
+++ b/backend/src/main/java/com/itec0401/backend/domain/coordination/controller/CoordinationController.java
@@ -2,7 +2,7 @@ package com.itec0401.backend.domain.coordination.controller;
 
 import com.itec0401.backend.domain.coordination.dto.BasicCodiRequestToSpring;
 import com.itec0401.backend.domain.coordination.dto.CodiDetails;
-import com.itec0401.backend.domain.coordination.dto.AllCodiInfo;
+import com.itec0401.backend.domain.coordination.dto.CodiInfoWithImages;
 import com.itec0401.backend.domain.coordination.dto.NLCodiRequestToSpring;
 import com.itec0401.backend.domain.coordination.service.CoordinationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,7 +36,7 @@ public class CoordinationController {
                     "추천된 결과는 바로 DB에 저장됨."
     )
     @PostMapping("/rec/natural-language")
-    public ResponseEntity<Void> coordRecommendUsingNaturalLanguage(@RequestBody NLCodiRequestToSpring dto, Authentication authentication){
+    public ResponseEntity<CodiInfoWithImages> coordRecommendUsingNaturalLanguage(@RequestBody NLCodiRequestToSpring dto, Authentication authentication){
         return coordinationService.coordRecommendUsingNaturalLanguage(dto, authentication);
     }
 
@@ -45,8 +45,8 @@ public class CoordinationController {
             description = "코디의 상세 정보가 열람되지는 않음. 추후 수정해야할 수도...(이미지 정보를 같이 반환하는 방향으로..)"
     )
     @GetMapping
-    public ResponseEntity<List<AllCodiInfo>> getAllCoordinationInfos(Authentication authentication){
-        return coordinationService.getAllCodiInfos(authentication);
+    public ResponseEntity<List<CodiInfoWithImages>> getAllCoordinationInfos(Authentication authentication){
+        return coordinationService.getAllCodiInfoWithImages(authentication);
     }
 
     @Operation(

--- a/backend/src/main/java/com/itec0401/backend/domain/coordination/dto/CodiInfoWithImages.java
+++ b/backend/src/main/java/com/itec0401/backend/domain/coordination/dto/CodiInfoWithImages.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-public class AllCodiInfo {
+public class CodiInfoWithImages {
     private final Long id;
     private final String name;
     private final String description;
@@ -16,7 +16,7 @@ public class AllCodiInfo {
     private final List<String> clothingImages;
 
     @Builder
-    public AllCodiInfo(Long id, String name, String description, String hashtags, LocalDateTime createdAt, List<String> clothingImages) {
+    public CodiInfoWithImages(Long id, String name, String description, String hashtags, LocalDateTime createdAt, List<String> clothingImages) {
         this.id = id;
         this.name = name;
         this.description = description;

--- a/backend/src/main/java/com/itec0401/backend/domain/coordination/dto/NLCodiRequestToSpring.java
+++ b/backend/src/main/java/com/itec0401/backend/domain/coordination/dto/NLCodiRequestToSpring.java
@@ -1,5 +1,7 @@
 package com.itec0401.backend.domain.coordination.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,12 +9,11 @@ import java.util.List;
 
 @Getter
 public class NLCodiRequestToSpring {
-    private final List<Long> clothing;
     private final String natural_language;
 
+    @JsonCreator
     @Builder
-    public NLCodiRequestToSpring(List<Long> clothing, String natural_language) {
-        this.clothing = clothing;
+    public NLCodiRequestToSpring(@JsonProperty("natural_language") String natural_language) {
         this.natural_language = natural_language;
     }
 }

--- a/backend/src/main/java/com/itec0401/backend/domain/coordination/service/CoordinationService.java
+++ b/backend/src/main/java/com/itec0401/backend/domain/coordination/service/CoordinationService.java
@@ -2,7 +2,7 @@ package com.itec0401.backend.domain.coordination.service;
 
 import com.itec0401.backend.domain.coordination.dto.BasicCodiRequestToSpring;
 import com.itec0401.backend.domain.coordination.dto.CodiDetails;
-import com.itec0401.backend.domain.coordination.dto.AllCodiInfo;
+import com.itec0401.backend.domain.coordination.dto.CodiInfoWithImages;
 import com.itec0401.backend.domain.coordination.dto.NLCodiRequestToSpring;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -11,8 +11,8 @@ import java.util.List;
 
 public interface CoordinationService {
     ResponseEntity<Void> coordRecommendBasic(BasicCodiRequestToSpring dto, Authentication authentication);
-    ResponseEntity<Void> coordRecommendUsingNaturalLanguage(NLCodiRequestToSpring dto, Authentication authentication);
-    ResponseEntity<List<AllCodiInfo>> getAllCodiInfos(Authentication authentication);
+    ResponseEntity<CodiInfoWithImages> coordRecommendUsingNaturalLanguage(NLCodiRequestToSpring dto, Authentication authentication);
+    ResponseEntity<List<CodiInfoWithImages>> getAllCodiInfoWithImages(Authentication authentication);
     ResponseEntity<Integer> deleteCodiById(Long id, Authentication authentication);
     ResponseEntity<CodiDetails> getCoordinationDetails(Long id, Authentication authentication);
 }

--- a/backend/src/main/java/com/itec0401/backend/domain/coordination/service/CoordinationServiceImpl.java
+++ b/backend/src/main/java/com/itec0401/backend/domain/coordination/service/CoordinationServiceImpl.java
@@ -74,6 +74,8 @@ public class CoordinationServiceImpl implements CoordinationService {
             coordinationRepository.save(coordination);  // 먼저 Coordination 생성하고 다른 테이블에서 참조해야 잘 참조됨.
             // CoordinationClothingService 사용하기 - N:M 매핑 하기
             for (Long id : temp.getClothing_ids()) {
+                System.out.println(id);
+                if (id == null) continue;
                 coordinationClothingService.createCoordinationClothing(coordination, clothingService.getClothingEntity(id, authentication));
             }
         }


### PR DESCRIPTION
### 1. 옷 삭제 API

- 옷이 삭제될 시 GCS에서 옷 사진도 같이 삭제되도록 Python API 연결

### 2. NL 코디 추천

- POST 요청시 반환값 추가
- Request Json 에서 clothing id 리스트를 삭제하고, 자동으로 유저가 소유한 옷 정보가 들어가게 수정
- LLM 추천 결과로 나온 코디에 사용되는 Clothing id가 null로 나오는 경우 해결

### 3. Basic 코디 추천

- LLM 추천 결과로 나온 코디에 사용되는 Clothing id가 null로 나오는 경우 해결